### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/jkoolcloud/tnt4j/App.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/App.java
@@ -6,6 +6,9 @@ package com.jkoolcloud.tnt4j;
  */
 public class App 
 {
+    private App() {
+    }
+    
     public static void main( String[] args )
     {
         System.out.println( "Hello World!" );

--- a/src/main/java/com/jkoolcloud/tnt4j/logger/AppenderTools.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/logger/AppenderTools.java
@@ -39,6 +39,9 @@ import com.jkoolcloud.tnt4j.utils.Utils;
  */
 public class AppenderTools implements AppenderConstants {
 
+    private AppenderTools() {
+    }
+    
 	/**
 	 * Strip type qualifier from a given key
 	 *

--- a/src/main/java/com/jkoolcloud/tnt4j/utils/MathUtils.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/utils/MathUtils.java
@@ -27,6 +27,9 @@ import java.util.List;
  */
 public class MathUtils {
 	
+    private MathUtils() {
+    }
+    
 	/**
 	 * Compute low Bollinger band value. Same as {@code getBBLow(List, 2, 20)}
 	 *

--- a/src/main/java/com/jkoolcloud/tnt4j/utils/SizeOf.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/utils/SizeOf.java
@@ -30,6 +30,10 @@ import java.util.Map;
  * @version $Revision: 2 $
  */
 public class SizeOf {
+    
+    private SizeOf() {
+    }
+    
 	/**
 	 * Instance of java.lang.instrument.Instrument injected by the Java VM
 	 *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed