### PR TITLE
Code quality fix - "instanceof" operators that always return "true" or "false" should be removed.

### DIFF
--- a/src/main/java/com/jkoolcloud/tnt4j/core/UsecTimestamp.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/core/UsecTimestamp.java
@@ -511,9 +511,6 @@ public class UsecTimestamp extends Number implements Comparable<UsecTimestamp>, 
 	 * @param other timestamp to add to current one
 	 */
 	public void add(UsecTimestamp other) {
-		if (!(other instanceof UsecTimestamp))
-			throw new ClassCastException("Cannot add " + this.getClass().getName() + " to " + other.getClass().getName());
-
 		add(other.msecs, other.usecs);
 	}
 
@@ -553,9 +550,6 @@ public class UsecTimestamp extends Number implements Comparable<UsecTimestamp>, 
 	 * @param other timestamp to subtract from current one
 	 */
 	public void subtract(UsecTimestamp other) {
-		if (!(other instanceof UsecTimestamp))
-			throw new ClassCastException("Cannot subtract " + this.getClass().getName() + " and " + other.getClass().getName());
-
 		subtract(other.msecs, other.usecs);
 	}
 
@@ -601,8 +595,6 @@ public class UsecTimestamp extends Number implements Comparable<UsecTimestamp>, 
 	 * @return difference, in microseconds, between two timestamps
 	 */
 	public long difference(UsecTimestamp other) {
-		if (!(other instanceof UsecTimestamp))
-			throw new ClassCastException("Cannot compare " + this.getClass().getName() + " to " + other.getClass().getName());
 
 		long thisMsecs = this.msecs;
 		long thisUsecs = this.usecs;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1850 - "instanceof" operators that always return "true" or "false" should be removed
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1850

Please let me know if you have any questions.

Faisal Hameed