### PR TITLE
Code quality fix - Lazy initialization of "static" fields should be "synchronized".

### DIFF
--- a/src/main/java/com/jkoolcloud/tnt4j/utils/TimeService.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/utils/TimeService.java
@@ -81,7 +81,7 @@ public class TimeService {
 	 * Schedule automatic clock synchronization with NTP and internal clocks
 	 *
 	 */
-	private static void scheduleUpdates() {
+	private static synchronized void scheduleUpdates() {
 		if (scheduler == null) {
 			scheduler = Executors.newScheduledThreadPool(1, new TimeServiceThreadFactory("TimeService/clock-sync"));
 			clockSyncTask = new ClockDriftMonitorTask(logger);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2444 - Lazy initialization of "static" fields should be "synchronized"
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2444

Please let me know if you have any questions.

Faisal Hameed