### PR TITLE
Code quality fix - Modifiers should be declared in the correct order.

### DIFF
--- a/src/main/java/com/jkoolcloud/tnt4j/dump/DefaultDumpProvider.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/dump/DefaultDumpProvider.java
@@ -27,7 +27,7 @@ package com.jkoolcloud.tnt4j.dump;
  *
  */
 
-abstract public class DefaultDumpProvider implements DumpProvider {
+public abstract class DefaultDumpProvider implements DumpProvider {
 	String pname, category;
 
 	/**

--- a/src/main/java/com/jkoolcloud/tnt4j/sink/AbstractEventSink.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/sink/AbstractEventSink.java
@@ -573,7 +573,7 @@ public abstract class AbstractEventSink implements EventSink, EventSinkStats {
 	 * @throws Exception if error logging tracking event
 	 * @see TrackingEvent
 	 */
-	abstract protected void _log(TrackingEvent event) throws Exception;
+	protected abstract void _log(TrackingEvent event) throws Exception;
 
 	/**
 	 * Override this method to add actual implementation for all subclasses.
@@ -582,7 +582,7 @@ public abstract class AbstractEventSink implements EventSink, EventSinkStats {
 	 * @throws Exception if error logging tracking activity
 	 * @see TrackingActivity
 	 */
-	abstract protected void _log(TrackingActivity activity) throws Exception;;
+	protected abstract void _log(TrackingActivity activity) throws Exception;;
 
 	/**
 	 * Override this method to add actual implementation for all subclasses.
@@ -591,7 +591,7 @@ public abstract class AbstractEventSink implements EventSink, EventSinkStats {
 	 * @throws Exception if error logging snapshot
 	 * @see OpLevel
 	 */
-	abstract protected void _log(Snapshot snapshot) throws Exception;
+	protected abstract void _log(Snapshot snapshot) throws Exception;
 
 	/**
 	 * Override this method to add actual implementation for all subclasses.
@@ -609,7 +609,7 @@ public abstract class AbstractEventSink implements EventSink, EventSinkStats {
 	 * @throws Exception if logging message
 	 * @see OpLevel
 	 */
-	abstract protected void _log(long ttl, Source src, OpLevel sev, String msg, Object... args) throws Exception;
+	protected abstract void _log(long ttl, Source src, OpLevel sev, String msg, Object... args) throws Exception;
 
 	/**
 	 * Override this method to add actual implementation for all subclasses.
@@ -621,5 +621,5 @@ public abstract class AbstractEventSink implements EventSink, EventSinkStats {
 	 * @throws IOException if error writing to sink
 	 * @throws InterruptedException if interrupted during write operation
 	 */
-	abstract protected void _write(Object msg, Object...args) throws IOException, InterruptedException;
+	protected abstract void _write(Object msg, Object...args) throws IOException, InterruptedException;
 }

--- a/src/main/java/com/jkoolcloud/tnt4j/sink/AbstractEventSinkFactory.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/sink/AbstractEventSinkFactory.java
@@ -46,7 +46,7 @@ import com.jkoolcloud.tnt4j.utils.Utils;
  *
  */
 
-abstract public class AbstractEventSinkFactory implements EventSinkFactory, Configurable {
+public abstract class AbstractEventSinkFactory implements EventSinkFactory, Configurable {
 	private SinkEventFilter eventFilter = null;
 	private SinkErrorListener errorListener = null;
 	private SinkLogEventListener eventListener = null;

--- a/src/main/java/com/jkoolcloud/tnt4j/source/SourceFactoryImpl.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/source/SourceFactoryImpl.java
@@ -41,13 +41,13 @@ import com.jkoolcloud.tnt4j.utils.Utils;
  * 
  */
 public class SourceFactoryImpl implements SourceFactory, Configurable {
-	public final static String UNKNOWN_SOURCE = "UNKNOWN";
-	public final static String DEFAULT_SOURCE_ROOT_SSN = System.getProperty("tnt4j.source.root.ssn", "tnt4j");
-	public final static String DEFAULT_SOURCE_ROOT_FQN = System.getProperty("tnt4j.source.root.fqname", "RUNTIME=?#SERVER=?#NETADDR=?#DATACENTER=?#GEOADDR=?");
+	public static final String UNKNOWN_SOURCE = "UNKNOWN";
+	public static final String DEFAULT_SOURCE_ROOT_SSN = System.getProperty("tnt4j.source.root.ssn", "tnt4j");
+	public static final String DEFAULT_SOURCE_ROOT_FQN = System.getProperty("tnt4j.source.root.fqname", "RUNTIME=?#SERVER=?#NETADDR=?#DATACENTER=?#GEOADDR=?");
 	
-	private final static String TNT4J_SOURCE_PFIX = "tnt4j.source.";	
-	private final static String USER_NAME_KEY = "user.name";	
-	private final static String [] DEFAULT_SOURCES;
+	private static final String TNT4J_SOURCE_PFIX = "tnt4j.source.";	
+	private static final String USER_NAME_KEY = "user.name";	
+	private static final String [] DEFAULT_SOURCES;
 	
 	static {
 		int i = 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.

Faisal Hameed