### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/src/main/java/com/jkoolcloud/tnt4j/TrackingLogger.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/TrackingLogger.java
@@ -238,6 +238,12 @@ public class TrackingLogger implements Tracker {
 		if (dumpOnException) dumpOnUncaughtException();
 		if (flushOnVmHook) flushOnShutdown(flushOnVmHook);
 	}
+	
+	/** Cannot instantiate. */
+    private TrackingLogger(Tracker trg) {
+    	logger = trg;
+    	selector = logger.getTrackingSelector();
+    }
 
 	/**
 	 * Check and enable java timing for use by activities
@@ -270,12 +276,6 @@ public class TrackingLogger implements Tracker {
 	private static void registerTracker(TrackingLogger tracker) {
 		TRACKERS.put(tracker, Thread.currentThread().getStackTrace());
 	}
-
-	/** Cannot instantiate. */
-    private TrackingLogger(Tracker trg) {
-    	logger = trg;
-    	selector = logger.getTrackingSelector();
-    }
 
 	/**
 	 * Obtain an allocation stack trace for the specified logger instance

--- a/src/main/java/com/jkoolcloud/tnt4j/core/UsecTimestamp.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/core/UsecTimestamp.java
@@ -49,26 +49,6 @@ public class UsecTimestamp extends Number implements Comparable<UsecTimestamp>, 
 	private long currentLamportClock = LamportCounter.incrementAndGet();
 
 	/**
-	 * Returns Lamport clock value of this time stamp
-	 * (based on Lamport Clock algorithm)
-	 *
-	 * @return Lamport clock value
-	 */
-	public long getLamportClock() {
-		return currentLamportClock;
-	}
-
-	/**
-	 * Returns UsecTimestamp based on current time with microsecond precision/accuracy
-	 *
-	 * @return UsecTimestamp for current time
-	 * @see com.jkoolcloud.tnt4j.utils.Utils#currentTimeUsec
-	 */
-	public static UsecTimestamp now() {
-		return new UsecTimestamp();
-	}
-
-	/**
 	 * Creates UsecTimestamp based on current time with microsecond precision/accuracy
 	 *
 	 * @see com.jkoolcloud.tnt4j.utils.Utils#currentTimeUsec
@@ -319,6 +299,46 @@ public class UsecTimestamp extends Number implements Comparable<UsecTimestamp>, 
 		setTimestampValues(date.getTime(), 0, 0);
 		add(0, usecs);
 	}
+	
+	/**
+	 * Creates UsecTimestamp based on specified UsecTimestamp.
+	 *
+	 * @param other timestamp to copy
+	 * @throws NullPointerException if timestamp is <code>null</code>
+	 */
+	public UsecTimestamp(UsecTimestamp other) {
+		this(other.msecs, other.usecs, other.getLamportClock());
+	}
+
+	/**
+	 * Creates UsecTimestamp based on specified UsecTimestamp.
+	 *
+	 * @param date timestamp to copy
+	 * @throws NullPointerException if date is <code>null</code>
+	 */
+	public UsecTimestamp(Date date) {
+		setTimestampValues(date.getTime(), 0, 0);
+	}
+	
+	/**
+	 * Returns Lamport clock value of this time stamp
+	 * (based on Lamport Clock algorithm)
+	 *
+	 * @return Lamport clock value
+	 */
+	public long getLamportClock() {
+		return currentLamportClock;
+	}
+
+	/**
+	 * Returns UsecTimestamp based on current time with microsecond precision/accuracy
+	 *
+	 * @return UsecTimestamp for current time
+	 * @see com.jkoolcloud.tnt4j.utils.Utils#currentTimeUsec
+	 */
+	public static UsecTimestamp now() {
+		return new UsecTimestamp();
+	}
 
 	/**
 	 * Sets UsecTimestamp based on specified microsecond timestamp.
@@ -391,26 +411,6 @@ public class UsecTimestamp extends Number implements Comparable<UsecTimestamp>, 
 				currentLamportClock = LamportCounter.incrementAndGet();
 			}
 		}
-	}
-
-	/**
-	 * Creates UsecTimestamp based on specified UsecTimestamp.
-	 *
-	 * @param other timestamp to copy
-	 * @throws NullPointerException if timestamp is <code>null</code>
-	 */
-	public UsecTimestamp(UsecTimestamp other) {
-		this(other.msecs, other.usecs, other.getLamportClock());
-	}
-
-	/**
-	 * Creates UsecTimestamp based on specified UsecTimestamp.
-	 *
-	 * @param date timestamp to copy
-	 * @throws NullPointerException if date is <code>null</code>
-	 */
-	public UsecTimestamp(Date date) {
-		setTimestampValues(date.getTime(), 0, 0);
 	}
 
 	/**

--- a/src/main/java/com/jkoolcloud/tnt4j/sink/DefaultEventSinkFactory.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/sink/DefaultEventSinkFactory.java
@@ -66,6 +66,12 @@ public class DefaultEventSinkFactory {
 	static {
 		LoadDefaultFactory();
 	}
+	
+	/**
+	 * Private constructor to prevent object instantiation
+	 *
+	 */
+	private DefaultEventSinkFactory() {}
 
 	/**
 	 * Initialize default even sink factory based on given environment.
@@ -104,12 +110,6 @@ public class DefaultEventSinkFactory {
 		}
 		return null;
 	}
-
-	/**
-	 * Private constructor to prevent object instantiation
-	 *
-	 */
-	private DefaultEventSinkFactory() {}
 
 	/**
 	 * Obtain a default event sink factory

--- a/src/main/java/com/jkoolcloud/tnt4j/tracker/TimeTracker.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/tracker/TimeTracker.java
@@ -44,6 +44,19 @@ public class TimeTracker {
 	 * Timing cache maintains timing since last hit for a specific key
 	 */
 	final Cache<String, TimeStats> EVENT_CACHE;
+	
+	/**
+	 * Create a time tracker with specified capacity and life span
+	 * 
+	 * @param capacity
+	 *            maximum capacity
+	 * @param lifeSpan life span in milliseconds
+	 */
+	private TimeTracker(int capacity, long lifeSpan) {
+		EVENT_CACHE = CacheBuilder.newBuilder().concurrencyLevel(Runtime.getRuntime().availableProcessors()).recordStats()
+				.maximumSize(capacity).expireAfterWrite(lifeSpan, TimeUnit.MILLISECONDS).build();	
+		EVENT_MAP = EVENT_CACHE.asMap();
+	}
 
 	/**
 	 * Create a default time tracker with specified capacity and life span
@@ -78,19 +91,6 @@ public class TimeTracker {
 	 */
 	public static TimeStats getStats() {
 		return THREAD_TIMER.get();
-	}
-	
-	/**
-	 * Create a time tracker with specified capacity and life span
-	 * 
-	 * @param capacity
-	 *            maximum capacity
-	 * @param lifeSpan life span in milliseconds
-	 */
-	private TimeTracker(int capacity, long lifeSpan) {
-		EVENT_CACHE = CacheBuilder.newBuilder().concurrencyLevel(Runtime.getRuntime().availableProcessors()).recordStats()
-				.maximumSize(capacity).expireAfterWrite(lifeSpan, TimeUnit.MILLISECONDS).build();	
-		EVENT_MAP = EVENT_CACHE.asMap();
 	}
 	
 	/**

--- a/src/main/java/com/jkoolcloud/tnt4j/tracker/TrackingEvent.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/tracker/TrackingEvent.java
@@ -121,56 +121,6 @@ public class TrackingEvent extends Message implements Trackable, Relate2<Source>
 	private OpType relationType = OpType.NOOP;
 
 	/**
-	 * Return string representation of this tracking event
-	 *
-	 * @return string representation of the tracking event
-	 */
-	@Override
-	public String toString() {
-		return 	"{" + operation.getSeverity()
-				+ ",[" + getMessage() + "],"
-				+ "[" + operation.getName() + "],"
-				+ super.toString()
-				+ "," + operation + "}";
-	}
-
-	/**
-	 * Returns true of operation is a NOOP
-	 *
-	 * @return true if operation is a NOOP, false otherwise
-	 */
-	public boolean isNoop() {
-		return operation.isNoop();
-	}
-
-	/**
-	 * Determine if operation was ever started
-	 *
-	 * @return true if operation was started, false otherwise
-	 */
-	public boolean isStarted() {
-		return operation.isStarted();
-	}
-
-	/**
-	 * Determine if operation was ever stopped
-	 *
-	 * @return true if operation was stopped, false otherwise
-	 */
-	public boolean isStopped() {
-		return operation.isStopped();
-	}
-
-	/**
-	 * Return current severity level associated with this event
-	 *
-	 * @return severity level
-	 */
-	public OpLevel getSeverity() {
-		return operation.getSeverity();
-	}
-
-	/**
 	 * Create a new NOOP tracking event
 	 * This constructor will assign a unique event signature using newUUID() call
 	 *
@@ -337,6 +287,56 @@ public class TrackingEvent extends Message implements Trackable, Relate2<Source>
 		setSource(src);
 		setLocation(src);
 		setTag(tag);
+	}
+	
+	/**
+	 * Return string representation of this tracking event
+	 *
+	 * @return string representation of the tracking event
+	 */
+	@Override
+	public String toString() {
+		return 	"{" + operation.getSeverity()
+				+ ",[" + getMessage() + "],"
+				+ "[" + operation.getName() + "],"
+				+ super.toString()
+				+ "," + operation + "}";
+	}
+
+	/**
+	 * Returns true of operation is a NOOP
+	 *
+	 * @return true if operation is a NOOP, false otherwise
+	 */
+	public boolean isNoop() {
+		return operation.isNoop();
+	}
+
+	/**
+	 * Determine if operation was ever started
+	 *
+	 * @return true if operation was started, false otherwise
+	 */
+	public boolean isStarted() {
+		return operation.isStarted();
+	}
+
+	/**
+	 * Determine if operation was ever stopped
+	 *
+	 * @return true if operation was stopped, false otherwise
+	 */
+	public boolean isStopped() {
+		return operation.isStopped();
+	}
+
+	/**
+	 * Return current severity level associated with this event
+	 *
+	 * @return severity level
+	 */
+	public OpLevel getSeverity() {
+		return operation.getSeverity();
 	}
 
 	@Override

--- a/src/main/java/com/jkoolcloud/tnt4j/utils/SizeOf.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/utils/SizeOf.java
@@ -31,9 +31,7 @@ import java.util.Map;
  */
 public class SizeOf {
     
-    private SizeOf() {
-    }
-    
+   
 	/**
 	 * Instance of java.lang.instrument.Instrument injected by the Java VM
 	 *
@@ -44,6 +42,9 @@ public class SizeOf {
 	private static boolean SKIP_STATIC_FIELD = false;
 	private static boolean SKIP_FINAL_FIELD = false;
 	private static boolean SKIP_FLYWEIGHT_FIELD = false;
+	
+    private SizeOf() {
+    }
 
 	/**
 	 * Callback method used by the Java VM to inject the java.lang.instrument.Instrument instance

--- a/src/main/java/com/jkoolcloud/tnt4j/utils/Utils.java
+++ b/src/main/java/com/jkoolcloud/tnt4j/utils/Utils.java
@@ -74,6 +74,12 @@ public class Utils {
 	 * 16-bit USC character set.
 	 */
 	public static final String UTF16 = "UTF-16BE";
+	
+
+	/**
+	 * Line feed.
+	 */
+	private static final String LINE_FEED = "\n";
 
 	/**
 	 * JVM runtime name
@@ -429,8 +435,6 @@ public class Utils {
 			throw new RuntimeException(ex);
 		}
 	}
-
-	private static final String LINE_FEED = "\n";
 
 	/**
 	 * Gets a MD5 message digester object


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed